### PR TITLE
feat(search): clamp limits + max_limit config + SPARQL row ceiling (hq-gkd)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,57 @@ use serde::Deserialize;
 
 use crate::namespace;
 
+/// The single source of truth for how aggressively search layers oversample
+/// candidates before post-filtering. Previously scattered as inline `*10`,
+/// `*5`, `*3` literals across the search/graphiti/vector paths (hq-gkd).
+pub const DEFAULT_OVERSAMPLE_FACTOR: usize = 10;
+
+/// Search/limit guardrails (hq-gkd). Without these, callers could pass
+/// `limit: 1_000_000` and unbounded SPARQL could scan the whole fact log.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SearchConfig {
+    /// Result count used when a caller omits a limit (default: 10).
+    pub default_limit: usize,
+
+    /// Hard ceiling a caller-supplied limit is clamped to (default: 1000).
+    pub max_limit: usize,
+
+    /// Multiplier for how many candidates to fetch before post-filtering
+    /// (default: `DEFAULT_OVERSAMPLE_FACTOR`).
+    pub oversample_factor: usize,
+
+    /// Server-side ceiling on rows returned by a SPARQL query, bounding
+    /// unbounded (LIMIT-less) scans (default: 10000).
+    pub max_sparql_rows: usize,
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            default_limit: 10,
+            max_limit: 1000,
+            oversample_factor: DEFAULT_OVERSAMPLE_FACTOR,
+            max_sparql_rows: 10_000,
+        }
+    }
+}
+
+impl SearchConfig {
+    /// Resolve a caller-supplied limit: fall back to `default_limit` when
+    /// absent, clamp to `max_limit`, and never return 0.
+    pub fn clamp_limit(&self, requested: Option<u64>) -> usize {
+        let v = requested.map_or(self.default_limit, |v| v as usize);
+        v.min(self.max_limit).max(1)
+    }
+
+    /// Number of candidates to fetch before post-filtering for a target result
+    /// count, using the unified oversample factor (saturating).
+    pub fn oversample(&self, limit: usize) -> usize {
+        limit.saturating_mul(self.oversample_factor).max(limit)
+    }
+}
+
 /// Vector storage backend selection.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -107,6 +158,9 @@ pub struct QuipuConfig {
 
     /// Entity resolution configuration.
     pub resolution: ResolutionConfig,
+
+    /// Search/limit guardrails.
+    pub search: SearchConfig,
 }
 
 impl Default for QuipuConfig {
@@ -120,6 +174,7 @@ impl Default for QuipuConfig {
             embedding: EmbeddingConfig::default(),
             vector: VectorConfig::default(),
             resolution: ResolutionConfig::default(),
+            search: SearchConfig::default(),
         }
     }
 }
@@ -244,6 +299,36 @@ impl QuipuConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn search_clamp_limit() {
+        let cfg = SearchConfig::default(); // default_limit=10, max_limit=1000
+        // Absent → default.
+        assert_eq!(cfg.clamp_limit(None), 10);
+        // In range → unchanged.
+        assert_eq!(cfg.clamp_limit(Some(50)), 50);
+        // Over the ceiling → clamped (the 1_000_000 attack).
+        assert_eq!(cfg.clamp_limit(Some(1_000_000)), 1000);
+        // Zero → never returns an empty page.
+        assert_eq!(cfg.clamp_limit(Some(0)), 1);
+    }
+
+    #[test]
+    fn search_oversample_uses_unified_factor() {
+        let cfg = SearchConfig::default(); // factor = DEFAULT_OVERSAMPLE_FACTOR (10)
+        assert_eq!(cfg.oversample(10), 10 * DEFAULT_OVERSAMPLE_FACTOR);
+        // Saturating + never below the input.
+        assert_eq!(cfg.oversample(usize::MAX), usize::MAX);
+    }
+
+    #[test]
+    fn search_defaults() {
+        let cfg = SearchConfig::default();
+        assert_eq!(cfg.default_limit, 10);
+        assert_eq!(cfg.max_limit, 1000);
+        assert_eq!(cfg.oversample_factor, DEFAULT_OVERSAMPLE_FACTOR);
+        assert_eq!(cfg.max_sparql_rows, 10_000);
+    }
 
     #[test]
     fn defaults() {

--- a/src/context/tools.rs
+++ b/src/context/tools.rs
@@ -53,10 +53,9 @@ pub fn tool_unified_search(store: &Store, input: &serde_json::Value) -> Result<s
         .and_then(|v| v.as_str())
         .ok_or_else(|| crate::error::Error::InvalidValue("missing 'query' parameter".into()))?;
 
-    let limit = input
-        .get("limit")
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(10) as usize;
+    let limit = store
+        .search_config()
+        .clamp_limit(input.get("limit").and_then(serde_json::Value::as_u64));
 
     let expand_links = input
         .get("expand_links")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@ pub mod vector_delegate;
 pub mod vector_lance;
 
 pub use config::{
-    EmbeddingConfig, FederationConfig, QuipuConfig, RemoteEndpoint, ResolutionConfig, ServerConfig,
-    VectorBackend, VectorConfig,
+    EmbeddingConfig, FederationConfig, QuipuConfig, RemoteEndpoint, ResolutionConfig, SearchConfig,
+    ServerConfig, VectorBackend, VectorConfig,
 };
 pub use context::{
     ContextPipeline, ContextPipelineConfig, KnowledgeContext, KnowledgeEntity, KnowledgeFact,

--- a/src/mcp/graphiti.rs
+++ b/src/mcp/graphiti.rs
@@ -24,10 +24,9 @@ pub fn tool_search_nodes(store: &Store, input: &JsonValue) -> Result<JsonValue> 
         .and_then(|v| v.as_str())
         .ok_or_else(|| Error::InvalidValue("missing 'query' parameter".into()))?;
 
-    let max_results = input
-        .get("max_results")
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(10) as usize;
+    let max_results = store
+        .search_config()
+        .clamp_limit(input.get("max_results").and_then(serde_json::Value::as_u64));
 
     let entity_type_filter = input.get("entity_type_filter").and_then(|v| v.as_str());
     let group_ids: Option<Vec<&str>> = input.get("group_ids").and_then(|v| {
@@ -42,7 +41,9 @@ pub fn tool_search_nodes(store: &Store, input: &JsonValue) -> Result<JsonValue> 
         .flatten()
         .and_then(|emb| {
             // Oversample to leave room for post-filtering.
-            store.vector_search(&emb, max_results * 3, None).ok()
+            store
+                .vector_search(&emb, store.search_config().oversample(max_results), None)
+                .ok()
         });
 
     let mut seen_entities = std::collections::HashSet::new();
@@ -76,7 +77,7 @@ pub fn tool_search_nodes(store: &Store, input: &JsonValue) -> Result<JsonValue> 
     // CONTAINS/LCASE aren't supported in Quipu's SPARQL, so we fetch all
     // labelled entities and filter in Rust.
     if nodes.len() < max_results {
-        let oversample = max_results * 5;
+        let oversample = store.search_config().oversample(max_results);
 
         let sparql = format!(
             "SELECT DISTINCT ?s ?label WHERE {{ \

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -65,8 +65,20 @@ pub fn tool_query(store: &Store, input: &JsonValue) -> Result<JsonValue> {
 
     let result = sparql::query_temporal(store, query_str, &ctx)?;
 
+    // Server-side ceiling on rows returned, so a LIMIT-less query can't dump the
+    // whole fact log to the caller (hq-gkd). We surface `truncated` rather than
+    // silently dropping rows.
+    let max_rows = store.search_config().max_sparql_rows;
+
     match result {
-        QueryResult::Select { variables, rows } => {
+        QueryResult::Select {
+            variables,
+            mut rows,
+        } => {
+            let truncated = rows.len() > max_rows;
+            if truncated {
+                rows.truncate(max_rows);
+            }
             let json_rows: Vec<JsonValue> = rows
                 .iter()
                 .map(|row| {
@@ -81,11 +93,16 @@ pub fn tool_query(store: &Store, input: &JsonValue) -> Result<JsonValue> {
             Ok(serde_json::json!({
                 "variables": variables,
                 "rows": json_rows,
-                "count": json_rows.len()
+                "count": json_rows.len(),
+                "truncated": truncated
             }))
         }
         QueryResult::Ask(result) => Ok(serde_json::json!({ "result": result })),
-        QueryResult::Graph(triples) => {
+        QueryResult::Graph(mut triples) => {
+            let truncated = triples.len() > max_rows;
+            if truncated {
+                triples.truncate(max_rows);
+            }
             let json_triples: Vec<JsonValue> = triples
                 .iter()
                 .map(|t| {
@@ -98,7 +115,8 @@ pub fn tool_query(store: &Store, input: &JsonValue) -> Result<JsonValue> {
                 .collect();
             Ok(serde_json::json!({
                 "triples": json_triples,
-                "count": json_triples.len()
+                "count": json_triples.len(),
+                "truncated": truncated
             }))
         }
     }

--- a/src/mcp/search.rs
+++ b/src/mcp/search.rs
@@ -26,10 +26,9 @@ pub fn tool_search_nodes(store: &Store, input: &JsonValue) -> Result<JsonValue> 
         .and_then(|v| v.as_str())
         .ok_or_else(|| Error::InvalidValue("missing 'query' parameter".into()))?;
 
-    let max_results = input
-        .get("max_results")
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(10) as usize;
+    let max_results = store
+        .search_config()
+        .clamp_limit(input.get("max_results").and_then(serde_json::Value::as_u64));
 
     let entity_type_filter = input.get("entity_type_filter").and_then(|v| v.as_str());
 
@@ -40,7 +39,7 @@ pub fn tool_search_nodes(store: &Store, input: &JsonValue) -> Result<JsonValue> 
 
     // Build SPARQL to fetch candidate entities with optional type/group filters.
     // Oversample to allow for post-filter text matching reducing the set.
-    let oversample = max_results * 10;
+    let oversample = store.search_config().oversample(max_results);
     let mut patterns = String::new();
     if let Some(type_iri) = entity_type_filter {
         let safe_type = type_iri.replace('>', "\\>");
@@ -101,17 +100,16 @@ pub fn tool_search_facts(store: &Store, input: &JsonValue) -> Result<JsonValue> 
         .and_then(|v| v.as_str())
         .ok_or_else(|| Error::InvalidValue("missing 'query' parameter".into()))?;
 
-    let max_results = input
-        .get("max_results")
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(10) as usize;
+    let max_results = store
+        .search_config()
+        .clamp_limit(input.get("max_results").and_then(serde_json::Value::as_u64));
 
     let group_ids: Option<Vec<&str>> = input
         .get("group_ids")
         .and_then(|v| v.as_array())
         .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect());
 
-    let oversample = max_results * 10;
+    let oversample = store.search_config().oversample(max_results);
     let mut patterns = String::new();
     if let Some(ref gids) = group_ids {
         patterns.push_str(

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -193,6 +193,38 @@ fn test_tool_episode() {
 }
 
 #[test]
+fn test_tool_query_enforces_max_sparql_rows() {
+    // hq-gkd: a LIMIT-less SELECT must not dump the whole fact log — the server
+    // ceiling truncates the result and flags it.
+    let mut store = test_store_with_data(); // 2 Person entities, each w/ name + age
+    store.search_config_mut().max_sparql_rows = 1;
+
+    let result = tool_query(
+        &store,
+        &serde_json::json!({ "query": "SELECT ?s ?p ?o WHERE { ?s ?p ?o }" }),
+    )
+    .unwrap();
+
+    assert_eq!(
+        result["count"], 1,
+        "rows should be capped at max_sparql_rows"
+    );
+    assert_eq!(result["truncated"], true, "truncation must be surfaced");
+}
+
+#[test]
+fn test_tool_query_not_truncated_when_under_ceiling() {
+    let store = test_store_with_data();
+    let result = tool_query(
+        &store,
+        &serde_json::json!({ "query": "SELECT ?name WHERE { ?s <http://example.org/name> ?name }" }),
+    )
+    .unwrap();
+    assert_eq!(result["count"], 2);
+    assert_eq!(result["truncated"], false);
+}
+
+#[test]
 fn test_tool_episode_surfaces_resolution_hints() {
     // hq-uye: the episode handler must read the store's resolution policy and
     // surface dedup hints in its response (the engine was previously inert).

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -180,10 +180,9 @@ pub fn tool_search(store: &Store, input: &JsonValue) -> Result<JsonValue> {
         }
     };
 
-    let limit = input
-        .get("limit")
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(10) as usize;
+    let limit = store
+        .search_config()
+        .clamp_limit(input.get("limit").and_then(serde_json::Value::as_u64));
 
     let valid_at = input.get("valid_at").and_then(|v| v.as_str());
 
@@ -423,10 +422,9 @@ pub fn tool_hybrid_search(store: &Store, input: &JsonValue) -> Result<JsonValue>
         }
     };
 
-    let limit = input
-        .get("limit")
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(10) as usize;
+    let limit = store
+        .search_config()
+        .clamp_limit(input.get("limit").and_then(serde_json::Value::as_u64));
 
     let valid_at = input.get("valid_at").and_then(|v| v.as_str());
     let sparql_filter = input.get("sparql").and_then(|v| v.as_str());

--- a/src/server.rs
+++ b/src/server.rs
@@ -54,6 +54,10 @@ async fn main() {
         );
     }
 
+    // Apply search/limit guardrails so callers can't request unbounded result
+    // sets or scan the whole fact log (hq-gkd).
+    store.search_config_mut().clone_from(&config.search);
+
     if let (Some(model_path), Some(tokenizer_path)) = (
         &config.embedding.model_path,
         &config.embedding.tokenizer_path,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use rusqlite::{Connection, params};
 
-use crate::config::{EmbeddingConfig, ResolutionConfig};
+use crate::config::{EmbeddingConfig, ResolutionConfig, SearchConfig};
 use crate::embedding::EmbeddingProvider;
 use crate::error::{Error, Result};
 use crate::schema::INIT_SQL;
@@ -25,6 +25,10 @@ pub struct Store {
     /// disabled; the server sets it from `[quipu.resolution]` at startup so
     /// dedup actually fires on ingest (hq-uye).
     pub(crate) resolution_config: ResolutionConfig,
+    /// Search/limit guardrails. Defaults are conservative; the server sets
+    /// these from `[quipu.search]` at startup so callers can't request
+    /// unbounded result sets (hq-gkd).
+    pub(crate) search_config: SearchConfig,
     /// When set, vector search is delegated to an external provider (e.g.
     /// Bobbin's `LanceDB`). Auto-embedding on write is skipped.
     pub(crate) vector_delegate: Option<DelegatingVectorStore>,
@@ -118,6 +122,7 @@ impl Store {
             embedding_provider: None,
             embedding_config: EmbeddingConfig::default(),
             resolution_config: ResolutionConfig::default(),
+            search_config: SearchConfig::default(),
             vector_delegate: None,
             local_vector_backend: None,
             #[cfg(feature = "reactive-reasoner")]
@@ -148,6 +153,16 @@ impl Store {
     /// Get a reference to the entity-resolution config.
     pub fn resolution_config(&self) -> &ResolutionConfig {
         &self.resolution_config
+    }
+
+    /// Get a mutable reference to the search/limit config.
+    pub fn search_config_mut(&mut self) -> &mut SearchConfig {
+        &mut self.search_config
+    }
+
+    /// Get a reference to the search/limit config.
+    pub fn search_config(&self) -> &SearchConfig {
+        &self.search_config
     }
 
     /// Set an external vector search delegate.

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -75,7 +75,13 @@ pub trait KnowledgeVectorStore {
         valid_at: Option<&str>,
     ) -> Result<Vec<VectorMatch>> {
         // Default: ignore filter, oversample to give callers room to post-filter.
-        let oversample = if filter.is_some() { limit * 5 } else { limit };
+        // Uses the shared oversample factor (hq-gkd) so this matches the
+        // search-layer config default instead of a divergent inline literal.
+        let oversample = if filter.is_some() {
+            limit.saturating_mul(crate::config::DEFAULT_OVERSAMPLE_FACTOR)
+        } else {
+            limit
+        };
         self.vector_search(query, oversample, valid_at)
     }
 


### PR DESCRIPTION
## Bug

No global limit guardrails existed:
- All six search/context sites did `.unwrap_or(10)` with **no cap** — a caller could pass `limit: 1_000_000`.
- A LIMIT-less SPARQL query scanned the **entire fact log** into the response (`sparql/pattern.rs`).
- The oversample factor was a scattered grab-bag of inline `*10` / `*5` / `*3` literals.

## Fix

- **New `[quipu.search]` `SearchConfig`**: `default_limit` (10), `max_limit` (1000), `oversample_factor` (`DEFAULT_OVERSAMPLE_FACTOR` = 10), `max_sparql_rows` (10000), with `clamp_limit()` / `oversample()` helpers. Threaded onto `Store` (mirrors embedding/resolution config) and applied by the server at startup.
- **Clamp every caller limit** via `search_config().clamp_limit()`: `tool_search`, `tool_hybrid_search` (tools.rs), `tool_search_nodes`/`_facts` (search.rs), graphiti search, `unified_search` (context). Over-range → `max_limit`; absent → `default_limit`; never 0.
- **Unify oversample**: search.rs / graphiti.rs use `search_config().oversample()`; vector.rs's trait-default uses the shared `DEFAULT_OVERSAMPLE_FACTOR` constant instead of a divergent `*5`.
- **SPARQL ceiling**: `tool_query` caps SELECT/CONSTRUCT/DESCRIBE results at `max_sparql_rows` and surfaces `truncated` (no silent drop), copying the fragments-endpoint `.min()` pattern the bead pointed to.

### Scope note
The SPARQL ceiling is a **result-size** ceiling (bounds memory/transport from an unbounded query). Pushing limits into the scan/join planner to bound CPU is a larger, separable change — a `LIMIT` injected mid-scan without `ORDER BY` would silently change query semantics, so it's deliberately left as a follow-up rather than shipped unsafely here.

## Tests

`clamp_limit` (default / in-range / over-ceiling / zero), `oversample` factor, `SearchConfig` defaults; end-to-end the SPARQL ceiling fires and flags `truncated`, and a control under the ceiling does not. Full lib suite green (309) except the pre-existing, unrelated `context::tests::unified_search_text_only` (fails on clean `main`).

## Notes

- **Stacked on hq-uye (#15) / hq-tb4 (#14)** — merge those first; this collapses to its own commit once they land.

## AC (hq-gkd)

- [x] `[quipu.search]` default_limit/max_limit + clamp (`.min`)
- [x] server-side max_rows ceiling on SPARQL
- [x] uniform oversample
- [x] test

🤖 Generated with [Claude Code](https://claude.com/claude-code)