### PR TITLE
fix(search): tool_search honors group_ids + entity_type (hq-93d)

### DIFF
--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -762,6 +762,88 @@ fn test_search_results_include_source_field() {
     assert_eq!(result["results"][0]["source"], "knowledge");
 }
 
+/// Set up two entities in different tenant groups (via episode provenance),
+/// each carrying the SAME embedding so an unfiltered vector search returns both.
+/// Returns the shared embedding. (hq-93d test fixture)
+fn two_tenant_store() -> (Store, Vec<f32>) {
+    let mut store = Store::open_in_memory().unwrap();
+    tool_episode(
+        &mut store,
+        &serde_json::json!({
+            "name": "ep-a", "group_id": "rig-a",
+            "nodes": [{"name": "AlphaSvc", "type": "WebApplication"}], "edges": [],
+            "timestamp": "2026-04-04T00:00:00Z"
+        }),
+    )
+    .unwrap();
+    tool_episode(
+        &mut store,
+        &serde_json::json!({
+            "name": "ep-b", "group_id": "rig-b",
+            "nodes": [{"name": "BetaSvc", "type": "Database"}], "edges": [],
+            "timestamp": "2026-04-04T00:00:00Z"
+        }),
+    )
+    .unwrap();
+
+    let ns = crate::namespace::DEFAULT_BASE_NS;
+    let emb: Vec<f32> = (0..8).map(|i| (1.0 + i as f32 * 0.1).sin()).collect();
+    for name in ["AlphaSvc", "BetaSvc"] {
+        let id = store.intern(&format!("{ns}{name}")).unwrap();
+        store
+            .embed_entity(id, name, &emb, "2026-04-04T00:00:00Z")
+            .unwrap();
+    }
+    (store, emb)
+}
+
+#[test]
+fn test_tool_search_honors_group_ids() {
+    // hq-93d: an unscoped vector search leaks both tenants; scoping by group_ids
+    // must restrict results to that tenant.
+    let (store, emb) = two_tenant_store();
+
+    // Unscoped → both tenants visible (the leak this bead fixes).
+    let all = tool_search(
+        &store,
+        &serde_json::json!({ "embedding": emb, "limit": 10 }),
+    )
+    .unwrap();
+    assert_eq!(all["scoped"], false);
+    assert_eq!(all["count"], 2, "unscoped search sees every group");
+
+    // Scoped to rig-a → only AlphaSvc.
+    let scoped = tool_search(
+        &store,
+        &serde_json::json!({ "embedding": emb, "limit": 10, "group_ids": ["rig-a"] }),
+    )
+    .unwrap();
+    assert_eq!(scoped["scoped"], true);
+    let results = scoped["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1, "must not leak the rig-b entity");
+    assert!(results[0]["entity"].as_str().unwrap().contains("AlphaSvc"));
+}
+
+#[test]
+fn test_tool_search_honors_entity_type() {
+    // hq-93d: scoping by entity_type restricts to that class.
+    let (store, emb) = two_tenant_store();
+    let ns = crate::namespace::DEFAULT_BASE_NS;
+
+    let scoped = tool_search(
+        &store,
+        &serde_json::json!({
+            "embedding": emb, "limit": 10,
+            "entity_type": format!("{ns}Database")
+        }),
+    )
+    .unwrap();
+    assert_eq!(scoped["scoped"], true);
+    let results = scoped["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1, "only the Database-typed entity");
+    assert!(results[0]["entity"].as_str().unwrap().contains("BetaSvc"));
+}
+
 /// Deterministic embedding provider for testing query-text auto-embedding.
 struct TestProvider;
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -186,7 +186,42 @@ pub fn tool_search(store: &Store, input: &JsonValue) -> Result<JsonValue> {
 
     let valid_at = input.get("valid_at").and_then(|v| v.as_str());
 
-    let matches = store.vector_search(&embedding, limit, valid_at)?;
+    // Tenant isolation (hq-93d): a plain vector search returns matches from every
+    // group/type, leaking cross-rig results. When the caller scopes the search
+    // with `group_ids` and/or `entity_type`, restrict to entities in that scope.
+    let entity_type = input.get("entity_type").and_then(|v| v.as_str());
+    let group_ids: Option<Vec<&str>> = input
+        .get("group_ids")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect());
+
+    let scope = scoped_entity_iris(
+        store,
+        entity_type,
+        group_ids.as_deref(),
+        store.search_config().oversample(limit),
+    )?;
+
+    let matches = if let Some(ref allowed) = scope {
+        // Oversample, then keep only in-scope entities (works for both the
+        // SQLite backend and as a safety net over LanceDB pushdown). entity_type
+        // is also pushed down to LanceDB for efficiency.
+        let pushdown = entity_type.map(|t| format!("entity_type = '{t}'"));
+        let oversampled = store.search_config().oversample(limit);
+        store
+            .vector_store()
+            .vector_search_filtered(&embedding, oversampled, pushdown.as_deref(), valid_at)?
+            .into_iter()
+            .filter(|m| {
+                store
+                    .resolve(m.entity_id)
+                    .is_ok_and(|iri| allowed.contains(&iri))
+            })
+            .take(limit)
+            .collect::<Vec<_>>()
+    } else {
+        store.vector_search(&embedding, limit, valid_at)?
+    };
 
     let results: Vec<JsonValue> = matches
         .iter()
@@ -207,8 +242,58 @@ pub fn tool_search(store: &Store, input: &JsonValue) -> Result<JsonValue> {
 
     Ok(serde_json::json!({
         "results": results,
-        "count": results.len()
+        "count": results.len(),
+        "scoped": scope.is_some()
     }))
+}
+
+/// Resolve the set of entity IRIs permitted by an optional `entity_type` and/or
+/// `group_ids` scope, used to enforce tenant isolation on vector search
+/// (hq-93d). Returns `Ok(None)` when no scope is requested (caller wants the
+/// full graph). Group membership is resolved via
+/// `prov:wasGeneratedBy → episode → groupId`, matching the `search_nodes` path.
+fn scoped_entity_iris(
+    store: &Store,
+    entity_type: Option<&str>,
+    group_ids: Option<&[&str]>,
+    limit: usize,
+) -> Result<Option<std::collections::HashSet<String>>> {
+    let has_group = group_ids.is_some_and(|g| !g.is_empty());
+    if entity_type.is_none() && !has_group {
+        return Ok(None);
+    }
+
+    let mut patterns = String::new();
+    if let Some(type_iri) = entity_type {
+        let safe_type = type_iri.replace('>', "\\>");
+        patterns.push_str(&format!("?s a <{safe_type}> . "));
+    }
+    if has_group {
+        patterns.push_str(
+            "?s <http://www.w3.org/ns/prov#wasGeneratedBy> ?_episode . \
+             ?_episode <http://aegis.gastown.local/ontology/groupId> ?_gid . ",
+        );
+        let gid_filters: Vec<String> = group_ids
+            .unwrap()
+            .iter()
+            .map(|g| {
+                let safe = g.replace('\\', "\\\\").replace('\'', "\\'");
+                format!("?_gid = '{safe}'")
+            })
+            .collect();
+        patterns.push_str(&format!("FILTER({}) ", gid_filters.join(" || ")));
+    }
+
+    let sparql = format!("SELECT DISTINCT ?s WHERE {{ ?s ?p ?o . {patterns}}} LIMIT {limit}");
+    let result = sparql::query(store, &sparql)?;
+
+    let mut iris = std::collections::HashSet::new();
+    for row in result.rows() {
+        if let Some(Value::Ref(id)) = row.get("s") {
+            iris.insert(store.resolve(*id)?);
+        }
+    }
+    Ok(Some(iris))
 }
 
 /// MCP tool: `quipu_shapes` -- Manage persistent SHACL shapes.


### PR DESCRIPTION
## Bug

Vector `tool_search` did **no** group/type filtering — only `tool_hybrid_search` filtered, and only via a leaky 2-hop SPARQL post-filter. Agents running a semantic search got cross-rig / cross-tenant noise: a knowledge **isolation leak**.

## Fix

- `tool_search` now accepts `group_ids` and `entity_type`. When either is given, results are restricted to entities in that scope:
  - Group membership resolves through `prov:wasGeneratedBy → episode → groupId` (the same path `search_nodes` uses).
  - `entity_type` is pushed down to LanceDB for efficiency, with a candidate-IRI post-filter as the backend-agnostic safety net (and the only filter for the SQLite backend).
- A shared `scoped_entity_iris` helper builds the scope query and returns `None` (unfiltered) when no scope is requested, so existing unscoped callers are unaffected. The response now reports `scoped`.

## Tests

- Unscoped search sees **both** tenants (demonstrating the leak).
- Scoping by `group_ids` returns only the in-group entity (no rig-b leakage).
- Scoping by `entity_type` returns only the matching class.

Full lib suite green (311) except the pre-existing, unrelated `context::tests::unified_search_text_only` (fails on clean `main`).

## Notes

- **Stacked on hq-gkd (#16) / hq-uye (#15) / hq-tb4 (#14)** — merge those first (P2 order); this collapses to its own commit once they land.

## AC (hq-93d)

- [x] `tool_search` honors `group_ids` + `entity_type`
- [x] test isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)