### PR TITLE
fix(embedding): cap ONNX tokenizer length + fail loud on dim mismatch (hq-7v0)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -225,6 +225,11 @@ pub struct EmbeddingConfig {
 
     /// Embedding dimension (default: 384 for all-MiniLM-L6-v2).
     pub dimension: usize,
+
+    /// Maximum input tokens fed to the model; longer inputs are truncated
+    /// (default: 256). Caps the tensor size so an oversized `episode_body`
+    /// can't blow up the sequence length or degrade embeddings (hq-7v0).
+    pub max_sequence_length: usize,
 }
 
 impl Default for EmbeddingConfig {
@@ -235,6 +240,7 @@ impl Default for EmbeddingConfig {
             model_path: None,
             tokenizer_path: None,
             dimension: 384,
+            max_sequence_length: 256,
         }
     }
 }

--- a/src/onnx_embedder.rs
+++ b/src/onnx_embedder.rs
@@ -19,6 +19,8 @@ pub struct OnnxEmbeddingProvider {
     session: Mutex<Session>,
     tokenizer: Tokenizer,
     dim: usize,
+    /// Hard cap on input tokens; longer inputs are truncated (hq-7v0).
+    max_seq_len: usize,
 }
 
 impl OnnxEmbeddingProvider {
@@ -28,19 +30,39 @@ impl OnnxEmbeddingProvider {
     /// * `model_path` — Path to the ONNX model file (model.onnx)
     /// * `tokenizer_path` — Path to the tokenizer.json file
     /// * `dim` — Expected embedding dimension (e.g. 384)
-    pub fn load(model_path: &Path, tokenizer_path: &Path, dim: usize) -> Result<Self> {
+    /// * `max_seq_len` — Hard cap on input tokens; longer inputs are truncated
+    ///   to bound the tensor size (hq-7v0). Falls back to 256 if zero.
+    pub fn load(
+        model_path: &Path,
+        tokenizer_path: &Path,
+        dim: usize,
+        max_seq_len: usize,
+    ) -> Result<Self> {
         let session = Session::builder()
             .and_then(|b| b.with_intra_threads(1))
             .and_then(|b| b.commit_from_file(model_path))
             .map_err(|e| crate::Error::Store(format!("ONNX session init failed: {e}")))?;
 
-        let tokenizer = Tokenizer::from_file(tokenizer_path)
+        let mut tokenizer = Tokenizer::from_file(tokenizer_path)
             .map_err(|e| crate::Error::Store(format!("Tokenizer load failed: {e}")))?;
+
+        let max_seq_len = if max_seq_len == 0 { 256 } else { max_seq_len };
+
+        // Truncate at the tokenizer so encodings never exceed the model's
+        // sequence limit (hq-7v0). Without this, a long episode_body produces an
+        // oversized tensor (runtime error / degraded, quadratic-cost embeddings).
+        tokenizer
+            .with_truncation(Some(tokenizers::TruncationParams {
+                max_length: max_seq_len,
+                ..Default::default()
+            }))
+            .map_err(|e| crate::Error::Store(format!("Tokenizer truncation config failed: {e}")))?;
 
         Ok(Self {
             session: Mutex::new(session),
             tokenizer,
             dim,
+            max_seq_len,
         })
     }
 
@@ -56,11 +78,16 @@ impl OnnxEmbeddingProvider {
             .map_err(|e| crate::Error::Store(format!("Tokenization failed: {e}")))?;
 
         let batch_size = encodings.len();
+        // Clamp to the configured limit defensively: tokenizer truncation should
+        // already cap encodings, but bounding `max_len` (and every inner loop
+        // with `.take(max_len)`) guarantees no out-of-bounds write even if a
+        // tokenizer without truncation is ever wired in (hq-7v0).
         let max_len = encodings
             .iter()
             .map(|e| e.get_ids().len())
             .max()
-            .unwrap_or(0);
+            .unwrap_or(0)
+            .min(self.max_seq_len);
 
         // Build padded input tensors.
         let mut input_ids = vec![0i64; batch_size * max_len];
@@ -68,11 +95,11 @@ impl OnnxEmbeddingProvider {
         let mut token_type_ids = vec![0i64; batch_size * max_len];
 
         for (i, enc) in encodings.iter().enumerate() {
-            for (j, &id) in enc.get_ids().iter().enumerate() {
+            for (j, &id) in enc.get_ids().iter().take(max_len).enumerate() {
                 input_ids[i * max_len + j] = i64::from(id);
                 attention_mask[i * max_len + j] = 1;
             }
-            for (j, &tt) in enc.get_type_ids().iter().enumerate() {
+            for (j, &tt) in enc.get_type_ids().iter().take(max_len).enumerate() {
                 token_type_ids[i * max_len + j] = i64::from(tt);
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -66,6 +66,7 @@ async fn main() {
             model_path,
             tokenizer_path,
             config.embedding.dimension,
+            config.embedding.max_sequence_length,
         ) {
             Ok(provider) => {
                 let dim = provider.dimension();
@@ -445,7 +446,7 @@ async fn spotlight_handler(
         .ok_or_else(|| quipu::Error::InvalidValue("missing 'text' parameter".into()))?;
     let confidence = input
         .get("confidence")
-        .and_then(|v| v.as_f64())
+        .and_then(serde_json::Value::as_f64)
         .unwrap_or(0.5);
     let store = store.lock().unwrap();
     Ok(axum::Json(semweb::spotlight(&store, text, confidence)?))

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -168,6 +168,20 @@ impl KnowledgeVectorStore for Store {
             let valid_to: Option<String> = row.get(4)?;
 
             let stored = bytes_to_f32_slice(&blob);
+            // Fail loud on a dimension mismatch instead of silently scoring 0.0
+            // (hq-7v0): a stored vector whose dim ≠ the query/provider dim means
+            // the embedding model or dimension changed without a re-embed, and
+            // every cosine would be a meaningless 0.0.
+            if !stored.is_empty() && stored.len() != query_embedding.len() {
+                return Err(crate::Error::Store(format!(
+                    "embedding dimension mismatch: query has {} dims but the stored \
+                     vector for entity {} has {} — re-embed after changing the \
+                     embedding model/dimension",
+                    query_embedding.len(),
+                    entity_id,
+                    stored.len()
+                )));
+            }
             let score = cosine_similarity(query_embedding, &stored);
 
             matches.push(VectorMatch {
@@ -287,6 +301,33 @@ mod tests {
         assert_eq!(results[1].entity_id, e2); // Bob = similar
         assert!(results[0].score > results[1].score);
         assert!(results[1].score > results[2].score);
+    }
+
+    #[test]
+    fn dimension_mismatch_fails_loud() {
+        // hq-7v0: searching with a query whose dim differs from the stored
+        // vectors must error, not silently score every candidate 0.0.
+        let store = Store::open_in_memory().unwrap();
+        let e1 = store.intern("http://example.org/alice").unwrap();
+        store
+            .embed_entity(e1, "Alice", &make_embedding(1.0, 8), "2026-01-01")
+            .unwrap();
+
+        // 4-dim query vs 8-dim stored → loud error mentioning the dimensions.
+        let err = store
+            .vector_search(&make_embedding(1.0, 4), 3, None)
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("dimension mismatch"), "got: {msg}");
+
+        // Matching dimension still works.
+        assert_eq!(
+            store
+                .vector_search(&make_embedding(1.0, 8), 3, None)
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Bugs

1. **No tokenizer max-length cap** (`onnx_embedder.rs`): `max_len` was the longest encoding in the batch, so a long `episode_body` produced an oversized tensor — runtime error or degraded, quadratic-cost embeddings.
2. **Silent dimension mismatch** (`vector.rs`): a stored vector whose dim ≠ the query/provider dim scored `0.0` cosine instead of erroring, so a model/dimension change without a re-embed degraded search invisibly.

## Fixes

- **`[quipu.embedding] max_sequence_length`** (default 256). `OnnxEmbeddingProvider::load` configures tokenizer truncation to that length, and `embed_batch_inner` defensively clamps `max_len` and bounds every inner loop with `.take(max_len)` — an out-of-bounds write is impossible even if a non-truncating tokenizer is ever wired in. Threaded through the server startup caller.
- **`vector_search` fails loud** on a stored-vs-query dimension mismatch with a clear, actionable error ("re-embed after changing the embedding model/dimension") instead of a meaningless `0.0`.

## Tests

- `dimension_mismatch_fails_loud`: a 4-dim query against 8-dim stored vectors errors; a matching-dim query still works. Runs in the CI default/shacl matrix (vector backend is core, not onnx-gated).
- The ONNX truncation path compiles under `--features onnx` (the `quipu-server` bin); it isn't unit-tested because that needs a real model+tokenizer on disk, but the bounded loops are correct by construction.

Verified locally: `cargo fmt --check` clean, `cargo clippy` clean on `--no-default-features` + `--features shacl` (and the onnx-gated `quipu-server` bin), `cargo test` 279 (no-default) / 312 (shacl), 0 failures. Also tidied one redundant-closure nit in the server bin.

## AC (hq-7v0)

- [x] config `max_sequence_length` (default 256/512); truncate; test
- [x] dimension mismatch fails loud instead of silent 0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)