### PR TITLE
feat(shacl): auto-apply loaded shapes on episode ingest (hq-c6s)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,16 @@ impl SearchConfig {
     }
 }
 
+/// SHACL validation policy (hq-c6s).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct ShaclConfig {
+    /// Validate every write against the persistently-loaded shapes (those
+    /// stored via `quipu_shapes`), not just shapes carried inline on an
+    /// episode. Default false — opt in to enforce "start strict" on all writes.
+    pub validate_on_write: bool,
+}
+
 /// Vector storage backend selection.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -161,6 +171,9 @@ pub struct QuipuConfig {
 
     /// Search/limit guardrails.
     pub search: SearchConfig,
+
+    /// SHACL validation policy.
+    pub shacl: ShaclConfig,
 }
 
 impl Default for QuipuConfig {
@@ -175,6 +188,7 @@ impl Default for QuipuConfig {
             vector: VectorConfig::default(),
             resolution: ResolutionConfig::default(),
             search: SearchConfig::default(),
+            shacl: ShaclConfig::default(),
         }
     }
 }

--- a/src/episode/mod.rs
+++ b/src/episode/mod.rs
@@ -165,27 +165,20 @@ pub fn ingest_episode(
 ) -> Result<(i64, usize)> {
     let turtle = episode_to_turtle(episode, base_ns);
 
-    // SHACL validation gate: if shapes provided, validate before writing.
+    // SHACL validation gates, run before any write.
     #[cfg(feature = "shacl")]
-    if let Some(shapes) = &episode.shapes {
-        let feedback = shacl::validate_shapes(shapes, &turtle)?;
-        if !feedback.conforms {
-            let messages: Vec<String> = feedback
-                .results
-                .iter()
-                .map(|r| {
-                    format!(
-                        "{}: {} ({})",
-                        r.severity,
-                        r.message.as_deref().unwrap_or("no message"),
-                        r.focus_node
-                    )
-                })
-                .collect();
-            return Err(Error::ValidationFailed {
-                violations: feedback.violations,
-                messages,
-            });
+    {
+        // Shapes carried inline on the episode (existing behaviour).
+        if let Some(shapes) = &episode.shapes {
+            shacl_validate_or_reject(shapes, &turtle)?;
+        }
+        // Persistently-loaded shapes, when write-validation is enabled (hq-c6s).
+        // Without this, stored shapes only gate the `knot` path and episode
+        // writes go unvalidated — undermining quipu's "start strict" thesis.
+        if store.shacl_config().validate_on_write
+            && let Some(stored) = store.get_combined_shapes()?
+        {
+            shacl_validate_or_reject(&stored, &turtle)?;
         }
     }
 
@@ -201,6 +194,33 @@ pub fn ingest_episode(
         actor,
         Some(&source_str),
     )
+}
+
+/// Validate `data_turtle` against `shapes_turtle`, returning a `ValidationFailed`
+/// error that lists the violations when it does not conform (hq-c6s). Shared by
+/// the inline-shapes and persistent-shapes gates in `ingest_episode`.
+#[cfg(feature = "shacl")]
+fn shacl_validate_or_reject(shapes_turtle: &str, data_turtle: &str) -> Result<()> {
+    let feedback = shacl::validate_shapes(shapes_turtle, data_turtle)?;
+    if feedback.conforms {
+        return Ok(());
+    }
+    let messages: Vec<String> = feedback
+        .results
+        .iter()
+        .map(|r| {
+            format!(
+                "{}: {} ({})",
+                r.severity,
+                r.message.as_deref().unwrap_or("no message"),
+                r.focus_node
+            )
+        })
+        .collect();
+    Err(Error::ValidationFailed {
+        violations: feedback.violations,
+        messages,
+    })
 }
 
 /// Ingest multiple episodes in sequence, each as its own transaction.

--- a/src/episode/tests.rs
+++ b/src/episode/tests.rs
@@ -64,6 +64,40 @@ fn episode_to_turtle_generates_valid_rdf() {
 }
 
 #[test]
+#[cfg(feature = "shacl")]
+fn write_validation_enforces_loaded_shapes() {
+    // hq-c6s: persistently-loaded shapes must gate episode writes when
+    // validate_on_write is set — not just episode-inline shapes.
+    let mut store = Store::open_in_memory().unwrap();
+    let shape = r#"
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix aegis: <http://aegis.gastown.local/ontology/> .
+aegis:ServerShape a sh:NodeShape ;
+    sh:targetClass aegis:Server ;
+    sh:property [ sh:path aegis:hostname ; sh:minCount 1 ] .
+"#;
+    store
+        .load_shapes("server-shape", shape, "2026-01-01")
+        .unwrap();
+
+    // A Server node with no aegis:hostname → violates the loaded shape.
+    let ep = parse_episode(
+        r#"{ "name": "ep", "nodes": [{"name": "Server1", "type": "Server"}], "edges": [] }"#,
+    );
+
+    // Toggle OFF: the violating write is accepted — the pre-fix gap.
+    ingest_episode(&mut store, &ep, "2026-01-02T00:00:00Z", TEST_BASE_NS).unwrap();
+
+    // Toggle ON: the same write is now rejected against the loaded shape.
+    store.shacl_config_mut().validate_on_write = true;
+    let err = ingest_episode(&mut store, &ep, "2026-01-03T00:00:00Z", TEST_BASE_NS).unwrap_err();
+    assert!(
+        matches!(err, crate::error::Error::ValidationFailed { .. }),
+        "expected ValidationFailed, got: {err:?}"
+    );
+}
+
+#[test]
 fn resolution_fires_on_duplicate_node() {
     // hq-uye: with resolution enabled, ingesting an episode whose node matches
     // an existing entity (by rdfs:label) must surface a dedup hint — the engine

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub mod vector_lance;
 
 pub use config::{
     EmbeddingConfig, FederationConfig, QuipuConfig, RemoteEndpoint, ResolutionConfig, SearchConfig,
-    ServerConfig, VectorBackend, VectorConfig,
+    ServerConfig, ShaclConfig, VectorBackend, VectorConfig,
 };
 pub use context::{
     ContextPipeline, ContextPipelineConfig, KnowledgeContext, KnowledgeEntity, KnowledgeFact,

--- a/src/server.rs
+++ b/src/server.rs
@@ -58,6 +58,13 @@ async fn main() {
     // sets or scan the whole fact log (hq-gkd).
     store.search_config_mut().clone_from(&config.search);
 
+    // Apply the SHACL validation policy so episode writes can be gated against
+    // persistently-loaded shapes, not just episode-inline shapes (hq-c6s).
+    store.shacl_config_mut().clone_from(&config.shacl);
+    if config.shacl.validate_on_write {
+        eprintln!("SHACL write-validation enabled (loaded shapes enforced on every write)");
+    }
+
     if let (Some(model_path), Some(tokenizer_path)) = (
         &config.embedding.model_path,
         &config.embedding.tokenizer_path,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use rusqlite::{Connection, params};
 
-use crate::config::{EmbeddingConfig, ResolutionConfig, SearchConfig};
+use crate::config::{EmbeddingConfig, ResolutionConfig, SearchConfig, ShaclConfig};
 use crate::embedding::EmbeddingProvider;
 use crate::error::{Error, Result};
 use crate::schema::INIT_SQL;
@@ -29,6 +29,9 @@ pub struct Store {
     /// these from `[quipu.search]` at startup so callers can't request
     /// unbounded result sets (hq-gkd).
     pub(crate) search_config: SearchConfig,
+    /// SHACL validation policy. When `validate_on_write` is set, episode
+    /// ingest is validated against the persistently-loaded shapes (hq-c6s).
+    pub(crate) shacl_config: ShaclConfig,
     /// When set, vector search is delegated to an external provider (e.g.
     /// Bobbin's `LanceDB`). Auto-embedding on write is skipped.
     pub(crate) vector_delegate: Option<DelegatingVectorStore>,
@@ -123,6 +126,7 @@ impl Store {
             embedding_config: EmbeddingConfig::default(),
             resolution_config: ResolutionConfig::default(),
             search_config: SearchConfig::default(),
+            shacl_config: ShaclConfig::default(),
             vector_delegate: None,
             local_vector_backend: None,
             #[cfg(feature = "reactive-reasoner")]
@@ -163,6 +167,16 @@ impl Store {
     /// Get a reference to the search/limit config.
     pub fn search_config(&self) -> &SearchConfig {
         &self.search_config
+    }
+
+    /// Get a mutable reference to the SHACL validation config.
+    pub fn shacl_config_mut(&mut self) -> &mut ShaclConfig {
+        &mut self.shacl_config
+    }
+
+    /// Get a reference to the SHACL validation config.
+    pub fn shacl_config(&self) -> &ShaclConfig {
+        &self.shacl_config
     }
 
     /// Set an external vector search delegate.


### PR DESCRIPTION
## Gap

Quipu's "start strict" thesis was aspirational: SHACL gated episode ingest **only** when the episode carried *inline* shapes (`episode/mod.rs`). Persistently-loaded shapes (via `quipu_shapes` — e.g. the 886-line `aegis-ontology.shapes.ttl`) gated the `knot` path but **not** episode writes. So episode ingest was effectively unvalidated against the ontology's real shapes.

## Fix

- New **`[quipu.shacl] validate_on_write`** toggle (default `false`), threaded onto `Store` (mirrors the resolution/search config pattern) and applied at server startup (logs when enabled).
- `ingest_episode` now validates the generated turtle against the store's persistently-loaded shapes when the toggle is on, in addition to the existing inline-shapes gate. Both gates share one `shacl_validate_or_reject` helper.

## Test (shacl)

`write_validation_enforces_loaded_shapes`: with a loaded shape requiring a property the episode lacks, the violating write is **accepted** when the toggle is off (demonstrating the pre-fix gap) and **rejected** with `ValidationFailed` when on.

Verified locally: `cargo fmt --check` clean, `cargo clippy` clean on `--no-default-features` + `--features shacl`, `cargo test` 279 (no-default) / 313 (shacl), 0 failures.

## AC (hq-c6s)

- [x] config toggle to validate every write against loaded shapes
- [x] test reject-on-violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)