### PR TITLE
feat(server): bearer auth + read-only mode + CORS allowlist (hq-azs)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -202,6 +202,19 @@ pub struct ServerConfig {
 
     /// Bind address (default: `127.0.0.1:3030`).
     pub bind: String,
+
+    /// Bearer token required on write endpoints (hq-azs). When set, a write
+    /// must present `Authorization: Bearer <token>`. None (default) = open
+    /// writes, preserving today's LAN-trusted behaviour.
+    pub auth_token: Option<String>,
+
+    /// Reject all write endpoints with 403 (hq-azs). Reads stay available.
+    pub read_only: bool,
+
+    /// CORS origin allowlist (hq-azs). Empty (default) = allow any origin,
+    /// preserving the existing browser-tab behaviour; non-empty restricts
+    /// cross-origin requests to these exact origins.
+    pub cors_allowed_origins: Vec<String>,
 }
 
 impl Default for ServerConfig {
@@ -209,6 +222,9 @@ impl Default for ServerConfig {
         Self {
             enabled: false,
             bind: "127.0.0.1:3030".to_string(),
+            auth_token: None,
+            read_only: false,
+            cors_allowed_origins: Vec::new(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,16 @@ impl SearchConfig {
     }
 }
 
+/// SHACL validation policy (hq-c6s).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct ShaclConfig {
+    /// Validate every write against the persistently-loaded shapes (those
+    /// stored via `quipu_shapes`), not just shapes carried inline on an
+    /// episode. Default false — opt in to enforce "start strict" on all writes.
+    pub validate_on_write: bool,
+}
+
 /// Vector storage backend selection.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -161,6 +171,9 @@ pub struct QuipuConfig {
 
     /// Search/limit guardrails.
     pub search: SearchConfig,
+
+    /// SHACL validation policy.
+    pub shacl: ShaclConfig,
 }
 
 impl Default for QuipuConfig {
@@ -175,6 +188,7 @@ impl Default for QuipuConfig {
             vector: VectorConfig::default(),
             resolution: ResolutionConfig::default(),
             search: SearchConfig::default(),
+            shacl: ShaclConfig::default(),
         }
     }
 }

--- a/src/episode/mod.rs
+++ b/src/episode/mod.rs
@@ -165,27 +165,20 @@ pub fn ingest_episode(
 ) -> Result<(i64, usize)> {
     let turtle = episode_to_turtle(episode, base_ns);
 
-    // SHACL validation gate: if shapes provided, validate before writing.
+    // SHACL validation gates, run before any write.
     #[cfg(feature = "shacl")]
-    if let Some(shapes) = &episode.shapes {
-        let feedback = shacl::validate_shapes(shapes, &turtle)?;
-        if !feedback.conforms {
-            let messages: Vec<String> = feedback
-                .results
-                .iter()
-                .map(|r| {
-                    format!(
-                        "{}: {} ({})",
-                        r.severity,
-                        r.message.as_deref().unwrap_or("no message"),
-                        r.focus_node
-                    )
-                })
-                .collect();
-            return Err(Error::ValidationFailed {
-                violations: feedback.violations,
-                messages,
-            });
+    {
+        // Shapes carried inline on the episode (existing behaviour).
+        if let Some(shapes) = &episode.shapes {
+            shacl_validate_or_reject(shapes, &turtle)?;
+        }
+        // Persistently-loaded shapes, when write-validation is enabled (hq-c6s).
+        // Without this, stored shapes only gate the `knot` path and episode
+        // writes go unvalidated — undermining quipu's "start strict" thesis.
+        if store.shacl_config().validate_on_write
+            && let Some(stored) = store.get_combined_shapes()?
+        {
+            shacl_validate_or_reject(&stored, &turtle)?;
         }
     }
 
@@ -201,6 +194,33 @@ pub fn ingest_episode(
         actor,
         Some(&source_str),
     )
+}
+
+/// Validate `data_turtle` against `shapes_turtle`, returning a `ValidationFailed`
+/// error that lists the violations when it does not conform (hq-c6s). Shared by
+/// the inline-shapes and persistent-shapes gates in `ingest_episode`.
+#[cfg(feature = "shacl")]
+fn shacl_validate_or_reject(shapes_turtle: &str, data_turtle: &str) -> Result<()> {
+    let feedback = shacl::validate_shapes(shapes_turtle, data_turtle)?;
+    if feedback.conforms {
+        return Ok(());
+    }
+    let messages: Vec<String> = feedback
+        .results
+        .iter()
+        .map(|r| {
+            format!(
+                "{}: {} ({})",
+                r.severity,
+                r.message.as_deref().unwrap_or("no message"),
+                r.focus_node
+            )
+        })
+        .collect();
+    Err(Error::ValidationFailed {
+        violations: feedback.violations,
+        messages,
+    })
 }
 
 /// Ingest multiple episodes in sequence, each as its own transaction.

--- a/src/episode/tests.rs
+++ b/src/episode/tests.rs
@@ -64,6 +64,40 @@ fn episode_to_turtle_generates_valid_rdf() {
 }
 
 #[test]
+#[cfg(feature = "shacl")]
+fn write_validation_enforces_loaded_shapes() {
+    // hq-c6s: persistently-loaded shapes must gate episode writes when
+    // validate_on_write is set — not just episode-inline shapes.
+    let mut store = Store::open_in_memory().unwrap();
+    let shape = r#"
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix aegis: <http://aegis.gastown.local/ontology/> .
+aegis:ServerShape a sh:NodeShape ;
+    sh:targetClass aegis:Server ;
+    sh:property [ sh:path aegis:hostname ; sh:minCount 1 ] .
+"#;
+    store
+        .load_shapes("server-shape", shape, "2026-01-01")
+        .unwrap();
+
+    // A Server node with no aegis:hostname → violates the loaded shape.
+    let ep = parse_episode(
+        r#"{ "name": "ep", "nodes": [{"name": "Server1", "type": "Server"}], "edges": [] }"#,
+    );
+
+    // Toggle OFF: the violating write is accepted — the pre-fix gap.
+    ingest_episode(&mut store, &ep, "2026-01-02T00:00:00Z", TEST_BASE_NS).unwrap();
+
+    // Toggle ON: the same write is now rejected against the loaded shape.
+    store.shacl_config_mut().validate_on_write = true;
+    let err = ingest_episode(&mut store, &ep, "2026-01-03T00:00:00Z", TEST_BASE_NS).unwrap_err();
+    assert!(
+        matches!(err, crate::error::Error::ValidationFailed { .. }),
+        "expected ValidationFailed, got: {err:?}"
+    );
+}
+
+#[test]
 fn resolution_fires_on_duplicate_node() {
     // hq-uye: with resolution enabled, ingesting an episode whose node matches
     // an existing entity (by rdfs:label) must surface a dedup hint — the engine

--- a/src/http_auth.rs
+++ b/src/http_auth.rs
@@ -1,0 +1,167 @@
+//! Access-control decisions for the Quipu REST server (hq-azs).
+//!
+//! The server bin (`quipu-server`) is feature-gated behind `onnx`, so its axum
+//! wiring isn't exercised by the default CI matrix. The *policy* — is this a
+//! write? is it allowed under read-only mode? does the bearer token match? — is
+//! pure and lives here so it can be unit-tested without standing up a server.
+
+/// The set of write endpoints. A request to one of these mutates the fact log
+/// (or schema), so it is subject to read-only mode and bearer auth. Everything
+/// else (query, search, entity reads, UI, health) is treated as read-only and
+/// stays open. Kept in sync with the `rw_handler!` routes in `server.rs`.
+pub const WRITE_ENDPOINTS: &[&str] = &[
+    "/knot",
+    "/episode",
+    "/episodes/complete",
+    "/retract",
+    "/shapes",
+    "/impact",
+    "/propose",
+    "/proposal/accept",
+    "/proposal/reject",
+    "/embed_backfill",
+];
+
+/// Whether `path` is a write endpoint subject to auth / read-only policy.
+pub fn is_write_endpoint(path: &str) -> bool {
+    WRITE_ENDPOINTS.contains(&path)
+}
+
+/// Outcome of an access-control check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessDecision {
+    /// Proceed with the request.
+    Allow,
+    /// Reject: a bearer token is required or did not match (HTTP 401).
+    Unauthorized,
+    /// Reject: the server is read-only and this is a write (HTTP 403).
+    ReadOnly,
+}
+
+/// Decide whether a request may proceed.
+///
+/// Reads (`is_write == false`) are always allowed. Writes are rejected when the
+/// server is read-only, and — when an `auth_token` is configured — require a
+/// matching `Authorization: Bearer <token>` header. With no token configured,
+/// writes are open (today's LAN-trusted default).
+pub fn authorize(
+    is_write: bool,
+    read_only: bool,
+    auth_token: Option<&str>,
+    auth_header: Option<&str>,
+) -> AccessDecision {
+    if !is_write {
+        return AccessDecision::Allow;
+    }
+    if read_only {
+        return AccessDecision::ReadOnly;
+    }
+    match auth_token {
+        None => AccessDecision::Allow,
+        Some(expected) => match auth_header.and_then(parse_bearer) {
+            Some(presented) if constant_time_eq(presented.as_bytes(), expected.as_bytes()) => {
+                AccessDecision::Allow
+            }
+            _ => AccessDecision::Unauthorized,
+        },
+    }
+}
+
+/// Extract the token from an `Authorization: Bearer <token>` header value.
+/// Case-insensitive on the scheme; trims surrounding whitespace on the token.
+pub fn parse_bearer(header: &str) -> Option<&str> {
+    let header = header.trim_start();
+    let (scheme, rest) = header.split_at(header.find(' ')?);
+    if scheme.eq_ignore_ascii_case("Bearer") {
+        let token = rest.trim();
+        if token.is_empty() { None } else { Some(token) }
+    } else {
+        None
+    }
+}
+
+/// Length-checked, constant-time byte comparison so token validation does not
+/// leak length/prefix information through timing.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_always_allowed() {
+        // Even read-only + token-required, a read needs no auth.
+        assert_eq!(
+            authorize(false, true, Some("secret"), None),
+            AccessDecision::Allow
+        );
+    }
+
+    #[test]
+    fn read_only_blocks_writes() {
+        assert_eq!(authorize(true, true, None, None), AccessDecision::ReadOnly);
+        // Read-only wins even with a valid token.
+        assert_eq!(
+            authorize(true, true, Some("s"), Some("Bearer s")),
+            AccessDecision::ReadOnly
+        );
+    }
+
+    #[test]
+    fn writes_open_when_no_token_configured() {
+        assert_eq!(authorize(true, false, None, None), AccessDecision::Allow);
+    }
+
+    #[test]
+    fn writes_require_matching_bearer() {
+        assert_eq!(
+            authorize(true, false, Some("secret"), None),
+            AccessDecision::Unauthorized
+        );
+        assert_eq!(
+            authorize(true, false, Some("secret"), Some("Bearer wrong")),
+            AccessDecision::Unauthorized
+        );
+        assert_eq!(
+            authorize(true, false, Some("secret"), Some("Bearer secret")),
+            AccessDecision::Allow
+        );
+    }
+
+    #[test]
+    fn parse_bearer_forms() {
+        assert_eq!(parse_bearer("Bearer abc"), Some("abc"));
+        assert_eq!(parse_bearer("bearer abc"), Some("abc")); // case-insensitive scheme
+        assert_eq!(parse_bearer("Bearer   abc  "), Some("abc")); // trimmed
+        assert_eq!(parse_bearer("Basic abc"), None);
+        assert_eq!(parse_bearer("Bearer "), None);
+        assert_eq!(parse_bearer("abc"), None);
+    }
+
+    #[test]
+    fn write_endpoint_classification() {
+        assert!(is_write_endpoint("/episode"));
+        assert!(is_write_endpoint("/retract"));
+        assert!(is_write_endpoint("/proposal/accept"));
+        // Reads / unknown paths are not writes.
+        assert!(!is_write_endpoint("/query"));
+        assert!(!is_write_endpoint("/search"));
+        assert!(!is_write_endpoint("/health"));
+    }
+
+    #[test]
+    fn constant_time_eq_basics() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"ab"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub mod vector_lance;
 
 pub use config::{
     EmbeddingConfig, FederationConfig, QuipuConfig, RemoteEndpoint, ResolutionConfig, SearchConfig,
-    ServerConfig, VectorBackend, VectorConfig,
+    ServerConfig, ShaclConfig, VectorBackend, VectorConfig,
 };
 pub use context::{
     ContextPipeline, ContextPipelineConfig, KnowledgeContext, KnowledgeEntity, KnowledgeFact,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod embedding;
 pub mod episode;
 pub mod error;
 pub mod graph;
+pub mod http_auth;
 pub mod impact;
 pub mod mcp;
 #[cfg(feature = "lancedb")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -58,6 +58,13 @@ async fn main() {
     // sets or scan the whole fact log (hq-gkd).
     store.search_config_mut().clone_from(&config.search);
 
+    // Apply the SHACL validation policy so episode writes can be gated against
+    // persistently-loaded shapes, not just episode-inline shapes (hq-c6s).
+    store.shacl_config_mut().clone_from(&config.shacl);
+    if config.shacl.validate_on_write {
+        eprintln!("SHACL write-validation enabled (loaded shapes enforced on every write)");
+    }
+
     if let (Some(model_path), Some(tokenizer_path)) = (
         &config.embedding.model_path,
         &config.embedding.tokenizer_path,

--- a/src/server.rs
+++ b/src/server.rs
@@ -96,6 +96,39 @@ async fn main() {
 
     let state: SharedStore = Arc::new(Mutex::new(store));
 
+    // Access-control policy for write endpoints (hq-azs). Decision logic lives
+    // in quipu::http_auth (unit-tested); this only wires it into axum.
+    let auth_token = config.server.auth_token.clone();
+    let read_only = config.server.read_only;
+    if read_only {
+        eprintln!("server is READ-ONLY — write endpoints will return 403");
+    }
+    if auth_token.is_some() {
+        eprintln!("write endpoints require a bearer token");
+    }
+
+    // CORS: an allowlist restricts cross-origin requests when configured; an
+    // empty list preserves the prior allow-any behaviour. AUTHORIZATION is
+    // allowed so a browser can present the bearer token cross-origin.
+    let cors_origins = config.server.cors_allowed_origins.clone();
+    let cors_base = if cors_origins.is_empty() {
+        tower_http::cors::CorsLayer::new().allow_origin(tower_http::cors::Any)
+    } else {
+        let origins: Vec<axum::http::HeaderValue> =
+            cors_origins.iter().filter_map(|o| o.parse().ok()).collect();
+        tower_http::cors::CorsLayer::new().allow_origin(origins)
+    };
+    let cors = cors_base
+        .allow_methods([
+            axum::http::Method::GET,
+            axum::http::Method::POST,
+            axum::http::Method::OPTIONS,
+        ])
+        .allow_headers([
+            axum::http::header::CONTENT_TYPE,
+            axum::http::header::AUTHORIZATION,
+        ]);
+
     if args.iter().any(|a| a == "--embed-backfill") {
         eprintln!("Running embedding backfill for all entities...");
         let mut s = state.lock().unwrap();
@@ -148,19 +181,40 @@ async fn main() {
         .route("/fragments", get(fragments_handler))
         .route("/reconcile", post(reconcile_handler))
         .route("/preview/{iri}", get(preview_handler))
+        // Auth / read-only guard on write endpoints (hq-azs). Added before the
+        // CORS layer so CORS stays outermost and answers OPTIONS preflight
+        // before the guard runs.
+        .layer(axum::middleware::from_fn(
+            move |req: axum::extract::Request, next: axum::middleware::Next| {
+                let auth_token = auth_token.clone();
+                async move {
+                    let is_write = quipu::http_auth::is_write_endpoint(req.uri().path());
+                    let auth_header = req
+                        .headers()
+                        .get(axum::http::header::AUTHORIZATION)
+                        .and_then(|v| v.to_str().ok())
+                        .map(str::to_string);
+                    match quipu::http_auth::authorize(
+                        is_write,
+                        read_only,
+                        auth_token.as_deref(),
+                        auth_header.as_deref(),
+                    ) {
+                        quipu::http_auth::AccessDecision::Allow => next.run(req).await,
+                        quipu::http_auth::AccessDecision::Unauthorized => {
+                            StatusCode::UNAUTHORIZED.into_response()
+                        }
+                        quipu::http_auth::AccessDecision::ReadOnly => {
+                            StatusCode::FORBIDDEN.into_response()
+                        }
+                    }
+                }
+            },
+        ))
         // CORS: allow the Bobbin Knowledge tab (and other browser origins) to
         // call /query, /search, /episode, etc. cross-origin, incl. OPTIONS
-        // preflight (GH#5).
-        .layer(
-            tower_http::cors::CorsLayer::new()
-                .allow_origin(tower_http::cors::Any)
-                .allow_methods([
-                    axum::http::Method::GET,
-                    axum::http::Method::POST,
-                    axum::http::Method::OPTIONS,
-                ])
-                .allow_headers([axum::http::header::CONTENT_TYPE]),
-        )
+        // preflight (GH#5). Built above from the configured allowlist.
+        .layer(cors)
         .with_state(state);
 
     eprintln!("quipu-server listening on {bind_addr} (db: {db_path})");

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use rusqlite::{Connection, params};
 
-use crate::config::{EmbeddingConfig, ResolutionConfig, SearchConfig};
+use crate::config::{EmbeddingConfig, ResolutionConfig, SearchConfig, ShaclConfig};
 use crate::embedding::EmbeddingProvider;
 use crate::error::{Error, Result};
 use crate::schema::INIT_SQL;
@@ -29,6 +29,9 @@ pub struct Store {
     /// these from `[quipu.search]` at startup so callers can't request
     /// unbounded result sets (hq-gkd).
     pub(crate) search_config: SearchConfig,
+    /// SHACL validation policy. When `validate_on_write` is set, episode
+    /// ingest is validated against the persistently-loaded shapes (hq-c6s).
+    pub(crate) shacl_config: ShaclConfig,
     /// When set, vector search is delegated to an external provider (e.g.
     /// Bobbin's `LanceDB`). Auto-embedding on write is skipped.
     pub(crate) vector_delegate: Option<DelegatingVectorStore>,
@@ -123,6 +126,7 @@ impl Store {
             embedding_config: EmbeddingConfig::default(),
             resolution_config: ResolutionConfig::default(),
             search_config: SearchConfig::default(),
+            shacl_config: ShaclConfig::default(),
             vector_delegate: None,
             local_vector_backend: None,
             #[cfg(feature = "reactive-reasoner")]
@@ -163,6 +167,16 @@ impl Store {
     /// Get a reference to the search/limit config.
     pub fn search_config(&self) -> &SearchConfig {
         &self.search_config
+    }
+
+    /// Get a mutable reference to the SHACL validation config.
+    pub fn shacl_config_mut(&mut self) -> &mut ShaclConfig {
+        &mut self.shacl_config
+    }
+
+    /// Get a reference to the SHACL validation config.
+    pub fn shacl_config(&self) -> &ShaclConfig {
+        &self.shacl_config
     }
 
     /// Set an external vector search delegate.


### PR DESCRIPTION
## Risk

The REST server had **no auth** and CORS `allow_origin(Any)`; write endpoints (`/episode`, `/retract`, `/knot`, `/shapes`, `/propose`, …) were open. On a shared crew knowledge plane, any compromised agent was a full-write vector.

## Fix

- **New `[quipu.server]` knobs**: `auth_token` (Option), `read_only` (bool), `cors_allowed_origins` (Vec). Defaults preserve today's open LAN-trusted behaviour.
- **New `quipu::http_auth` lib module** holds the pure access-control policy — `authorize` / `is_write_endpoint` / `parse_bearer` / constant-time compare — so it's unit-tested in the default CI matrix even though the `quipu-server` bin is `onnx`-gated and outside it.
- **Thin axum middleware** in `server.rs`: writes are rejected **403** in read-only mode, and require a matching `Authorization: Bearer <token>` (**401** otherwise) when a token is configured; **reads stay open** so the browser Knowledge tab keeps working. CORS is built from the allowlist (empty = any), with `AUTHORIZATION` added to allowed headers so the token can be sent cross-origin. CORS stays outermost so OPTIONS preflight isn't auth-gated.

The write-endpoint set is kept in sync with the `rw_handler!` routes + the custom mutating handlers (knot/shapes/propose/proposal-accept/reject/embed_backfill).

## Tests

7 `http_auth` unit tests: reads-always-allowed, read-only blocks writes (even with a valid token), open-when-no-token, bearer match/mismatch/missing, bearer-parsing forms, write-endpoint classification, constant-time compare.

Verified locally: `cargo fmt --check` clean; `cargo clippy` clean on `--no-default-features` + `--features shacl`; the `quipu-server` bin builds under `--features shacl,onnx`; `cargo test` 286 (no-default) / 320 (shacl), 0 failures.

## Notes

- **Stacked on hq-c6s (#19)** — collapses to its own commit once #19 merges; I'll rebase onto main then.

## AC (hq-azs)

- [x] bearer token on writes
- [x] read-only mode flag
- [x] CORS allowlist config
- [x] test

🤖 Generated with [Claude Code](https://claude.com/claude-code)