### PR TITLE
fix(search): rank query-named entity above referencing nodes (hq-5gi)

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -277,32 +277,65 @@ impl<'a> ContextPipeline<'a> {
         self.text_search_sparql(query)
     }
 
-    /// SPARQL-based text search fallback (substring match, no ranking).
+    /// SPARQL-based text search fallback (substring match, lexical ranking).
     fn text_search_sparql(&self, query: &str) -> Result<Vec<KnowledgeEntity>> {
         // Escape single quotes for SPARQL injection safety.
         let safe_query = query.replace('\\', "\\\\").replace('\'', "\\'");
 
-        // Find entities that have any literal value containing the query string.
+        // A direct hit means the entity is itself *about* the query term: the
+        // term appears in its own IRI or in one of its literal values. Object
+        // IRI references are deliberately excluded — an entity that merely
+        // points at the query term (e.g. `ex:kota ex:manages ex:traefik` for
+        // the query "traefik") is a *linked* result, surfaced by link
+        // expansion, not a direct hit. Counting those as direct hits caused
+        // ranking drift where a referencing node could outrank the entity the
+        // query actually names (hq-5gi).
         let sparql = format!(
             "SELECT DISTINCT ?s WHERE {{ \
                 ?s ?p ?o . \
                 FILTER(CONTAINS(LCASE(STR(?s)), LCASE('{safe_query}')) || \
-                       CONTAINS(LCASE(STR(?o)), LCASE('{safe_query}'))) \
+                       (isLiteral(?o) && CONTAINS(LCASE(STR(?o)), LCASE('{safe_query}')))) \
             }} LIMIT {}",
             self.config.max_entities
         );
 
         let result = sparql::query(self.store, &sparql)?;
 
+        let lc_query = query.to_lowercase();
         let mut entities = Vec::new();
         for row in result.rows() {
             if let Some(Value::Ref(id)) = row.get("s") {
                 let iri = self.store.resolve(*id)?;
-                if let Ok(entity) = self.build_entity(&iri, KnowledgeRelevance::Direct, 1.0) {
+                // Provisional score; refined below once the label is known.
+                let iri_match = iri.to_lowercase().contains(&lc_query);
+                if let Ok(mut entity) = self.build_entity(&iri, KnowledgeRelevance::Direct, 1.0) {
+                    // Rank by where the match lands: an entity named by the
+                    // query (IRI or label) outranks one matched only via an
+                    // incidental literal value.
+                    let label_match = entity
+                        .label
+                        .as_deref()
+                        .is_some_and(|l| l.to_lowercase().contains(&lc_query));
+                    entity.score = if iri_match {
+                        1.0
+                    } else if label_match {
+                        0.9
+                    } else {
+                        0.7
+                    };
                     entities.push(entity);
                 }
             }
         }
+
+        // Deterministic ordering: score desc, then IRI asc as a stable
+        // tiebreaker so results don't depend on SPARQL row order.
+        entities.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.iri.cmp(&b.iri))
+        });
 
         Ok(entities)
     }

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -194,11 +194,10 @@ fn facts_have_correct_types() {
     assert_eq!(port.unwrap().value_type, FactValueType::Literal);
 }
 
-// hq-5gi: unified_search ranking drift — the top result for "traefik" is no
-// longer the traefik entity. Pre-existing on main (reds Test on every PR);
-// ignored as a stopgap until the ranking is fixed under hq-5gi.
+// hq-5gi: the SPARQL text-search fallback now ranks the entity the query
+// names above nodes that merely reference it, so "traefik" returns the
+// traefik entity first.
 #[test]
-#[ignore = "hq-5gi: unified_search ranking drift"]
 fn unified_search_text_only() {
     let store = setup_test_store();
     let input = serde_json::json!({


### PR DESCRIPTION
## Problem
The SPARQL text-search fallback (`text_search_sparql`) counted any entity whose IRI **or any object value** contained the query term as a direct hit at a flat score of `1.0`. Object IRI references were included, so `ex:kota ex:manages ex:traefik` became a direct hit for the query `"traefik"` and could tie-break **ahead of `ex:traefik` itself** — nondeterministically, by SPARQL row order.

This reddened `Test (default)` on every quipu PR; it had been masked by a `#[ignore = "hq-5gi"]` stopgap on `context::tests::unified_search_text_only`.

## Fix
- **Direct hits = entity's own identity.** Match the subject IRI or *literal* object values only (`isLiteral(?o)`). Object IRI references now surface via link expansion, where they belong.
- **Lexical ranking.** Score by match locus — IRI `1.0`, label `0.9`, literal-only `0.7` — and sort score-desc with IRI-asc as a deterministic tiebreaker so results no longer depend on SPARQL row order.
- **Un-ignore** the test; remove the stopgap comment.

## Verification
- `cargo fmt --all` clean
- `cargo clippy --no-default-features --all-targets -- -D warnings -A missing-docs` clean
- `cargo clippy --features shacl --all-targets -- -D warnings -A missing-docs` clean
- `cargo test --no-default-features` → 287 passed, **0 ignored**
- `cargo test --features shacl` → 321 passed, **0 ignored**

Closes hq-5gi.