### PR TITLE
docs: bump mcp tool count header to 23/24 (hq-h75 follow-up)

### DIFF
--- a/docs/book/src/reference/mcp-tools.md
+++ b/docs/book/src/reference/mcp-tools.md
@@ -4,8 +4,8 @@ Quipu exposes its API as MCP (Model Context Protocol) tools for agent
 integration. These tools are available when Quipu runs as a Bobbin subsystem
 or standalone MCP server.
 
-The registry (`tool_definitions()`) exposes **22 tools** in a default build, or
-**23** when built with the `owl` feature (which adds `quipu_load_ontology`).
+The registry (`tool_definitions()`) exposes **23 tools** in a default build, or
+**24** when built with the `owl` feature (which adds `quipu_load_ontology`).
 
 ## Tool Reference
 


### PR DESCRIPTION
Follow-up to #22. The named-query catalog added `quipu_ask`, bumping the registry to 23 tools (24 with `owl`). #22's prose header in `mcp-tools.md` still said 22/23 — the in-code `test_tool_definitions` count was updated but this doc line was missed. Two-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)