### PR TITLE
feat(episode): idempotent ingest via content-hash key (hq-fhc)

### DIFF
--- a/src/episode/mod.rs
+++ b/src/episode/mod.rs
@@ -163,9 +163,19 @@ pub fn ingest_episode(
     timestamp: &str,
     base_ns: &str,
 ) -> Result<(i64, usize)> {
-    let turtle = episode_to_turtle(episode, base_ns);
+    // Idempotency key (hq-fhc). The episode activity IRI is derived purely from
+    // the episode name, so re-ingesting the same name targets the same node. We
+    // stamp the activity with a content hash: identical re-ingests are no-ops,
+    // and a changed episode retracts the activity's stale provenance facts
+    // before re-asserting, instead of accumulating duplicate activity nodes.
+    let new_hash = episode_content_hash(episode);
+    let ep_local = sanitize_iri_local(&episode.name);
+    let ep_iri = format!("{base_ns}episode_{ep_local}");
+    let turtle = episode_to_turtle(episode, base_ns, &new_hash);
 
-    // SHACL validation gates, run before any write.
+    // SHACL validation gates, run before any write — and before the idempotency
+    // short-circuit, so a no-op re-ingest is still validated (e.g. if
+    // validate_on_write was toggled on since the last ingest).
     #[cfg(feature = "shacl")]
     {
         // Shapes carried inline on the episode (existing behaviour).
@@ -182,7 +192,26 @@ pub fn ingest_episode(
         }
     }
 
+    let existing_hash = current_content_hash(store, &ep_iri, base_ns)?;
+
+    // Idempotency fast path: same content already recorded → skip the write.
+    if existing_hash.as_deref() == Some(new_hash.as_str()) {
+        return Ok((NOOP_TX, 0));
+    }
+
     let actor = episode.source.as_deref();
+
+    // Existing episode whose content changed: retract the activity's prior
+    // facts (label/comment/source/groupId/contentHash) so the update replaces
+    // them rather than leaving stale active values. Only the activity node is
+    // retracted; its generated entities are reconciled by fact-level dedup.
+    // SHACL has already passed above, so this never half-mutates on rejection.
+    if existing_hash.is_some()
+        && let Some(ep_id) = store.lookup(&ep_iri)?
+    {
+        store.retract_entity(ep_id, None, timestamp, actor)?;
+    }
+
     let source_str = format!("episode:{}", episode.name);
 
     ingest_rdf(
@@ -194,6 +223,81 @@ pub fn ingest_episode(
         actor,
         Some(&source_str),
     )
+}
+
+/// Transaction id returned when an episode ingest is a no-op (the identical
+/// content was already recorded). Distinguishable from a real tx, which is
+/// always positive.
+pub const NOOP_TX: i64 = 0;
+
+/// Read the content hash currently stamped on an episode activity, if any.
+fn current_content_hash(store: &Store, ep_iri: &str, base_ns: &str) -> Result<Option<String>> {
+    let query = format!("SELECT ?h WHERE {{ <{ep_iri}> <{base_ns}contentHash> ?h }} LIMIT 1");
+    let result = crate::sparql::query(store, &query)?;
+    Ok(result.rows().first().and_then(|row| match row.get("h") {
+        Some(crate::types::Value::Str(s)) => Some(s.clone()),
+        _ => None,
+    }))
+}
+
+/// A stable content hash of an episode's asserted data (name, body, source,
+/// group, and its nodes/edges). Node and edge ordering is normalised so that
+/// reordering alone does not defeat idempotency. SHACL `shapes` are excluded —
+/// they gate validation but are not part of the asserted graph.
+///
+/// Uses FNV-1a so the digest is deterministic across processes and Rust
+/// versions (unlike `DefaultHasher`), which matters because the value is
+/// persisted and compared on later runs.
+fn episode_content_hash(episode: &Episode) -> String {
+    let mut parts: Vec<String> = vec![
+        format!("name={}", episode.name),
+        format!("body={}", episode.episode_body.as_deref().unwrap_or("")),
+        format!("source={}", episode.source.as_deref().unwrap_or("")),
+        format!("group={}", episode.group_id.as_deref().unwrap_or("")),
+    ];
+
+    let mut nodes: Vec<String> = episode
+        .nodes
+        .iter()
+        .map(|n| {
+            let mut props: Vec<String> = n
+                .properties
+                .as_ref()
+                .map(|m| m.iter().map(|(k, v)| format!("{k}={v}")).collect())
+                .unwrap_or_default();
+            props.sort();
+            format!(
+                "node:{}|{}|{}|{}",
+                n.name,
+                n.node_type.as_deref().unwrap_or(""),
+                n.description.as_deref().unwrap_or(""),
+                props.join(",")
+            )
+        })
+        .collect();
+    nodes.sort();
+
+    let mut edges: Vec<String> = episode
+        .edges
+        .iter()
+        .map(|e| format!("edge:{}|{}|{}", e.source, e.relation, e.target))
+        .collect();
+    edges.sort();
+
+    parts.extend(nodes);
+    parts.extend(edges);
+
+    format!("{:016x}", fnv1a_64(parts.join("\n").as_bytes()))
+}
+
+/// FNV-1a 64-bit hash — small, dependency-free, and deterministic across runs.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        hash ^= u64::from(b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
 }
 
 /// Validate `data_turtle` against `shapes_turtle`, returning a `ValidationFailed`
@@ -267,7 +371,7 @@ pub fn episode_provenance(
 
 // ── Turtle generation ──────────────────────────────────────────
 
-fn episode_to_turtle(episode: &Episode, base_ns: &str) -> String {
+fn episode_to_turtle(episode: &Episode, base_ns: &str, content_hash: &str) -> String {
     let mut ttl = String::new();
 
     // Prefixes.
@@ -297,6 +401,8 @@ fn episode_to_turtle(episode: &Episode, base_ns: &str) -> String {
     if let Some(gid) = &episode.group_id {
         ttl.push_str(&format!(" ;\n    aegis:groupId \"{}\"", escape_turtle(gid)));
     }
+    // Idempotency key for re-ingest detection (hq-fhc).
+    ttl.push_str(&format!(" ;\n    aegis:contentHash \"{content_hash}\""));
     ttl.push_str(" .\n\n");
 
     // Nodes.

--- a/src/episode/tests.rs
+++ b/src/episode/tests.rs
@@ -47,7 +47,7 @@ fn episode_to_turtle_generates_valid_rdf() {
     }"#,
     );
 
-    let ttl = episode_to_turtle(&ep, TEST_BASE_NS);
+    let ttl = episode_to_turtle(&ep, TEST_BASE_NS, &episode_content_hash(&ep));
 
     // Should contain prefixes.
     assert!(ttl.contains("@prefix aegis:"));
@@ -57,6 +57,8 @@ fn episode_to_turtle_generates_valid_rdf() {
     assert!(ttl.contains("aegis:episode_test-episode a prov:Activity"));
     assert!(ttl.contains("rdfs:label \"test-episode\""));
     assert!(ttl.contains("rdfs:comment \"Test body\""));
+    // Should carry the idempotency key (hq-fhc).
+    assert!(ttl.contains("aegis:contentHash"));
 
     // Should contain node.
     assert!(ttl.contains("aegis:alpha a aegis:ServiceType"));
@@ -276,8 +278,8 @@ fn minimal_episode_with_body_only() {
     let (tx_id, count) =
         ingest_episode(&mut store, &ep, "2026-04-04T14:00:00Z", TEST_BASE_NS).unwrap();
     assert!(tx_id > 0);
-    // Just the episode entity: type + label + comment = 3
-    assert_eq!(count, 3);
+    // Just the episode entity: type + label + comment + contentHash = 4
+    assert_eq!(count, 4);
 }
 
 #[test]
@@ -466,4 +468,105 @@ fn batch_stops_on_validation_failure() {
     // First episode should have been ingested before failure.
     let prov = episode_provenance(&store, "ok-ep", TEST_BASE_NS).unwrap();
     assert_eq!(prov.len(), 1);
+}
+
+// ── Idempotent ingest (hq-fhc) ──────────────────────────────────────
+
+/// Count the active object values of `subject pred ?v` in current state.
+fn active_values(store: &Store, subject_iri: &str, pred_iri: &str) -> Vec<String> {
+    let q = format!("SELECT ?v WHERE {{ <{subject_iri}> <{pred_iri}> ?v }}");
+    crate::sparql::query(store, &q)
+        .unwrap()
+        .rows()
+        .iter()
+        .filter_map(|r| match r.get("v") {
+            Some(crate::types::Value::Str(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn reingest_identical_episode_is_noop() {
+    let mut store = Store::open_in_memory().unwrap();
+    let ep = parse_episode(
+        r#"{
+        "name": "dedup-test",
+        "episode_body": "first body",
+        "source": "crew/mayor",
+        "nodes": [{"name": "alpha", "type": "Service", "description": "Alpha"}],
+        "edges": []
+    }"#,
+    );
+
+    let (tx1, count1) =
+        ingest_episode(&mut store, &ep, "2026-04-04T12:00:00Z", TEST_BASE_NS).unwrap();
+    assert!(tx1 > 0, "first ingest writes a real transaction");
+    assert!(count1 > 0, "first ingest asserts triples");
+
+    // Re-ingesting byte-identical content is a no-op.
+    let (tx2, count2) =
+        ingest_episode(&mut store, &ep, "2026-04-04T13:00:00Z", TEST_BASE_NS).unwrap();
+    assert_eq!(
+        tx2, NOOP_TX,
+        "identical re-ingest returns the no-op sentinel"
+    );
+    assert_eq!(count2, 0, "identical re-ingest writes nothing");
+
+    // The activity still has exactly one active label and one content hash —
+    // no duplicate provenance accumulated.
+    let ep_iri = format!("{TEST_BASE_NS}episode_dedup-test");
+    let label = format!("{}label", namespace::RDFS);
+    let chash = format!("{TEST_BASE_NS}contentHash");
+    assert_eq!(active_values(&store, &ep_iri, &label).len(), 1);
+    assert_eq!(active_values(&store, &ep_iri, &chash).len(), 1);
+}
+
+#[test]
+fn reingest_changed_episode_updates_without_duplicating() {
+    let mut store = Store::open_in_memory().unwrap();
+    let v1 = parse_episode(
+        r#"{
+        "name": "dedup-test",
+        "episode_body": "first body",
+        "source": "crew/mayor",
+        "nodes": [],
+        "edges": []
+    }"#,
+    );
+    ingest_episode(&mut store, &v1, "2026-04-04T12:00:00Z", TEST_BASE_NS).unwrap();
+
+    let v2 = parse_episode(
+        r#"{
+        "name": "dedup-test",
+        "episode_body": "second body",
+        "source": "crew/mayor",
+        "nodes": [],
+        "edges": []
+    }"#,
+    );
+    let (tx2, count2) =
+        ingest_episode(&mut store, &v2, "2026-04-04T13:00:00Z", TEST_BASE_NS).unwrap();
+    assert!(tx2 > 0, "changed content writes a real transaction");
+    assert!(count2 > 0);
+
+    // Exactly one active comment, and it is the updated value — the stale
+    // "first body" was retracted, not left alongside the new one.
+    let ep_iri = format!("{TEST_BASE_NS}episode_dedup-test");
+    let comment = format!("{}comment", namespace::RDFS);
+    let comments = active_values(&store, &ep_iri, &comment);
+    assert_eq!(comments, vec!["second body".to_string()]);
+
+    // And exactly one active content hash.
+    let chash = format!("{TEST_BASE_NS}contentHash");
+    assert_eq!(active_values(&store, &ep_iri, &chash).len(), 1);
+}
+
+#[test]
+fn content_hash_is_order_independent_for_nodes() {
+    let a =
+        parse_episode(r#"{ "name": "h", "nodes": [{"name": "x"}, {"name": "y"}], "edges": [] }"#);
+    let b =
+        parse_episode(r#"{ "name": "h", "nodes": [{"name": "y"}, {"name": "x"}], "edges": [] }"#);
+    assert_eq!(episode_content_hash(&a), episode_content_hash(&b));
 }


### PR DESCRIPTION
## Why
Re-ingesting an episode with the same name targets the same activity IRI (`episode_<name>`, derived purely from the name). The store already dedups identical active `(e,a,v)` facts, but there was **no explicit idempotency signal**, and a *changed* episode left **stale active provenance facts** (old label/comment/source) alongside the new ones. Repeated `mol-ontology-ingest` runs had no clean no-op path.

From quipu audit feature #9.

## What
- **Content-hash idempotency key.** Stamp the episode activity with `aegis:contentHash` — a stable **FNV-1a** digest of name/body/source/group + **order-normalized** nodes/edges. FNV (not `DefaultHasher`) because the value is persisted and compared across processes/Rust versions. SHACL `shapes` are excluded (validation config, not asserted data).
- **Identical re-ingest → no-op.** Short-circuits to `NOOP_TX` (0) / count 0, skipping the redundant write, retract, and re-embed work.
- **Changed re-ingest → update.** Retracts the activity's prior facts before re-asserting, so the update *replaces* stale provenance instead of accumulating duplicate activity facts. Only the activity node is retracted; generated entities reconcile via the store's existing fact-level dedup.
- **Validation still gates no-ops.** SHACL runs *before* the idempotency short-circuit, so a no-op re-ingest is still validated (e.g. if `validate_on_write` was toggled on since the last ingest).

## Tests
- `reingest_identical_episode_is_noop` — second ingest returns `NOOP_TX`/0; activity keeps exactly one active label + one content hash.
- `reingest_changed_episode_updates_without_duplicating` — changed body → exactly one active comment, equal to the new value; one active hash.
- `content_hash_is_order_independent_for_nodes`.
- Adjusted `minimal_episode_with_body_only` exact count (3→4) and `episode_to_turtle_generates_valid_rdf` for the new triple.

## Verification
- `cargo fmt --all --check` clean
- `cargo clippy --no-default-features --all-targets -- -D warnings -A missing-docs` clean
- `cargo clippy --features shacl --all-targets -- -D warnings -A missing-docs` clean
- `cargo test --no-default-features` → 298 passed
- `cargo test --features shacl` → 332 passed

Closes hq-fhc.