### PR TITLE
feat(episode): per-edge confidence qualifier on ingest (hq-cug6)

### DIFF
--- a/docs/book/src/architecture/episodes.md
+++ b/docs/book/src/architecture/episodes.md
@@ -71,6 +71,24 @@ change -- it packages that knowledge as an episode with typed nodes and edges.
 | `source` | Yes | Source entity name |
 | `target` | Yes | Target entity name |
 | `relation` | Yes | Relationship name (becomes predicate) |
+| `confidence` | No | Confidence qualifier for the generated triple (see below) |
+
+> **Edge confidence.** Supply `confidence` to grade how trustworthy an
+> AUTO-extracted edge is — either an enum (`"EXTRACTED"`, `"INFERRED"`,
+> `"AMBIGUOUS"`) or a `0`–`1` number. The bare triple is always asserted; when a
+> confidence is present the statement is *additionally* reified
+> (`rdf:Statement` with `rdf:subject`/`rdf:predicate`/`rdf:object`) and qualified
+> with `quipu:confidence`, so agents can filter or flag uncertain facts via
+> SPARQL. Omitting it (the common case) leaves an unqualified triple — fully
+> back-compatible.
+>
+> ```sparql
+> # All edges an agent flagged as merely inferred
+> SELECT ?s ?p ?o WHERE {
+>   ?stmt rdf:subject ?s ; rdf:predicate ?p ; rdf:object ?o ;
+>         quipu:confidence "INFERRED" .
+> }
+> ```
 
 ## How Ingestion Works
 

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -407,6 +407,7 @@ ex:alice rdfs:label "Alice the Great" .
                 source: "Foo".into(),
                 target: "Bar".into(),
                 relation: "dependsOn".into(),
+                confidence: None,
             }],
             shapes: None,
         };

--- a/src/episode/mod.rs
+++ b/src/episode/mod.rs
@@ -293,7 +293,10 @@ fn episode_content_hash(episode: &Episode) -> String {
                 e.source,
                 e.relation,
                 e.target,
-                e.confidence.as_ref().map(ToString::to_string).unwrap_or_default()
+                e.confidence
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_default()
             )
         })
         .collect();

--- a/src/episode/mod.rs
+++ b/src/episode/mod.rs
@@ -151,6 +151,13 @@ pub struct Edge {
     pub source: String,
     pub target: String,
     pub relation: String,
+    /// Optional confidence qualifier for the generated triple (hq-cug6, aegis-1p0
+    /// Gap 5). Lets agents flag uncertain AUTO-extracted facts for review. Accepts
+    /// an enum grade (`"EXTRACTED"`/`"INFERRED"`/`"AMBIGUOUS"`) or a 0–1 number;
+    /// when present the triple is reified and qualified with `quipu:confidence`.
+    /// Absent (the common case) = unqualified bare triple, fully back-compatible.
+    #[serde(default)]
+    pub confidence: Option<serde_json::Value>,
 }
 
 /// Ingest an episode into the store.
@@ -280,7 +287,15 @@ fn episode_content_hash(episode: &Episode) -> String {
     let mut edges: Vec<String> = episode
         .edges
         .iter()
-        .map(|e| format!("edge:{}|{}|{}", e.source, e.relation, e.target))
+        .map(|e| {
+            format!(
+                "edge:{}|{}|{}|{}",
+                e.source,
+                e.relation,
+                e.target,
+                e.confidence.as_ref().map(ToString::to_string).unwrap_or_default()
+            )
+        })
         .collect();
     edges.sort();
 
@@ -379,6 +394,7 @@ fn episode_to_turtle(episode: &Episode, base_ns: &str, content_hash: &str) -> St
     ttl.push_str(&format!("@prefix rdf: <{}> .\n", namespace::RDF));
     ttl.push_str(&format!("@prefix rdfs: <{}> .\n", namespace::RDFS));
     ttl.push_str(&format!("@prefix prov: <{}> .\n", namespace::PROV));
+    ttl.push_str(&format!("@prefix quipu: <{}> .\n", namespace::QUIPU));
     ttl.push_str(&format!("@prefix xsd: <{}> .\n\n", namespace::XSD));
 
     let ep_local = sanitize_iri_local(&episode.name);
@@ -461,9 +477,38 @@ fn episode_to_turtle(episode: &Episode, base_ns: &str, content_hash: &str) -> St
         let tgt = sanitize_iri_local(&edge.target);
         let rel = sanitize_iri_local(&edge.relation);
         ttl.push_str(&format!("aegis:{src} aegis:{rel} aegis:{tgt} .\n"));
+
+        // Optional confidence qualifier (hq-cug6). The bare triple above is always
+        // asserted (back-compat); when a confidence is supplied we additionally
+        // reify the statement so it can carry the qualifier and stay SPARQL-
+        // queryable. The reification IRI is derived deterministically from the
+        // triple so re-ingest dedups at fact level rather than accumulating.
+        if let Some(conf) = &edge.confidence
+            && let Some(literal) = confidence_literal(conf)
+        {
+            let stmt_hash = format!("{:016x}", fnv1a_64(format!("{src}|{rel}|{tgt}").as_bytes()));
+            ttl.push_str(&format!("aegis:stmt_{stmt_hash} a rdf:Statement ;\n"));
+            ttl.push_str(&format!("    rdf:subject aegis:{src} ;\n"));
+            ttl.push_str(&format!("    rdf:predicate aegis:{rel} ;\n"));
+            ttl.push_str(&format!("    rdf:object aegis:{tgt} ;\n"));
+            ttl.push_str(&format!("    quipu:confidence {literal} .\n"));
+        }
     }
 
     ttl
+}
+
+/// Render a confidence value as a Turtle literal, or `None` to skip it.
+///
+/// A string (e.g. `"EXTRACTED"`) becomes a plain quoted literal; a number (0–1)
+/// becomes an `xsd:decimal`. Other JSON shapes (bool/array/object/null) are
+/// ignored so a malformed field never corrupts the graph.
+fn confidence_literal(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => Some(format!("\"{}\"", escape_turtle(s))),
+        serde_json::Value::Number(n) => n.as_f64().map(|f| format!("\"{f}\"^^xsd:decimal")),
+        _ => None,
+    }
 }
 
 /// Sanitize a name into a valid IRI local name.

--- a/src/episode/tests.rs
+++ b/src/episode/tests.rs
@@ -624,7 +624,11 @@ fn edge_confidence_enum_persists_and_is_sparql_queryable() {
             _ => None,
         })
         .collect();
-    assert_eq!(vals, vec!["INFERRED".to_string()], "confidence is queryable");
+    assert_eq!(
+        vals,
+        vec!["INFERRED".to_string()],
+        "confidence is queryable"
+    );
 
     // The plain triple still exists (the qualifier is additive, not a
     // replacement). The reification uses rdf:subject/predicate/object, so only

--- a/src/episode/tests.rs
+++ b/src/episode/tests.rs
@@ -570,3 +570,103 @@ fn content_hash_is_order_independent_for_nodes() {
         parse_episode(r#"{ "name": "h", "nodes": [{"name": "y"}, {"name": "x"}], "edges": [] }"#);
     assert_eq!(episode_content_hash(&a), episode_content_hash(&b));
 }
+
+// ── Edge confidence qualifier (hq-cug6, aegis-1p0 Gap 5) ──────────────────
+
+/// An edge without a confidence field stays a bare triple — no reification,
+/// fully back-compatible with pre-hq-cug6 episodes.
+#[test]
+fn edge_without_confidence_is_a_bare_triple() {
+    let ep = parse_episode(
+        r#"{ "name": "ep", "edges": [{"source": "a", "target": "b", "relation": "knows"}] }"#,
+    );
+    let ttl = episode_to_turtle(&ep, TEST_BASE_NS, &episode_content_hash(&ep));
+    assert!(ttl.contains("aegis:a aegis:knows aegis:b ."));
+    assert!(
+        !ttl.contains("rdf:Statement"),
+        "no reification without a confidence field"
+    );
+    assert!(!ttl.contains("quipu:confidence"));
+}
+
+/// A confidence enum grade reifies the statement and the qualifier is queryable
+/// via SPARQL (the AC). The bare triple is still asserted alongside it.
+#[test]
+fn edge_confidence_enum_persists_and_is_sparql_queryable() {
+    let mut store = Store::open_in_memory().unwrap();
+    let ep = parse_episode(
+        r#"{
+        "name": "conf-test",
+        "edges": [
+            {"source": "svcA", "target": "svcB", "relation": "dependsOn", "confidence": "INFERRED"}
+        ]
+    }"#,
+    );
+    ingest_episode(&mut store, &ep, "2026-06-29T00:00:00Z", TEST_BASE_NS).unwrap();
+
+    // Find the confidence grade by matching the reified statement on its triple.
+    let q = format!(
+        "SELECT ?c WHERE {{ \
+           ?s <{rdf}subject> <{ns}svcA> ; \
+              <{rdf}predicate> <{ns}dependsOn> ; \
+              <{rdf}object> <{ns}svcB> ; \
+              <{quipu}confidence> ?c }}",
+        rdf = namespace::RDF,
+        ns = TEST_BASE_NS,
+        quipu = namespace::QUIPU,
+    );
+    let rows = crate::sparql::query(&store, &q).unwrap();
+    let vals: Vec<String> = rows
+        .rows()
+        .iter()
+        .filter_map(|r| match r.get("c") {
+            Some(crate::types::Value::Str(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(vals, vec!["INFERRED".to_string()], "confidence is queryable");
+
+    // The plain triple still exists (the qualifier is additive, not a
+    // replacement). The reification uses rdf:subject/predicate/object, so only
+    // the bare assertion matches `svcA dependsOn ?o`.
+    let bare = crate::sparql::query(
+        &store,
+        &format!(
+            "SELECT ?o WHERE {{ <{ns}svcA> <{ns}dependsOn> ?o }}",
+            ns = TEST_BASE_NS
+        ),
+    )
+    .unwrap();
+    assert_eq!(
+        bare.rows().len(),
+        1,
+        "bare triple asserted alongside the reified qualifier"
+    );
+}
+
+/// A numeric 0–1 confidence is emitted as an xsd:decimal literal.
+#[test]
+fn edge_confidence_numeric_emits_decimal() {
+    let ep = parse_episode(
+        r#"{ "name": "n", "edges": [{"source": "a", "target": "b", "relation": "rel", "confidence": 0.75}] }"#,
+    );
+    let ttl = episode_to_turtle(&ep, TEST_BASE_NS, &episode_content_hash(&ep));
+    assert!(ttl.contains("a rdf:Statement"));
+    assert!(
+        ttl.contains("quipu:confidence \"0.75\"^^xsd:decimal"),
+        "numeric confidence becomes a typed decimal literal; got:\n{ttl}"
+    );
+}
+
+/// Changing only an edge's confidence changes the content hash, so a re-ingest
+/// is not mistaken for a no-op.
+#[test]
+fn confidence_participates_in_content_hash() {
+    let a = parse_episode(
+        r#"{ "name": "h", "edges": [{"source": "a", "target": "b", "relation": "r", "confidence": "EXTRACTED"}] }"#,
+    );
+    let b = parse_episode(
+        r#"{ "name": "h", "edges": [{"source": "a", "target": "b", "relation": "r", "confidence": "AMBIGUOUS"}] }"#,
+    );
+    assert_ne!(episode_content_hash(&a), episode_content_hash(&b));
+}

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -21,6 +21,13 @@ pub const SHACL: &str = "http://www.w3.org/ns/shacl#";
 
 pub const BOBBIN: &str = "https://bobbin.dev/ontology#";
 
+// ── Quipu namespace ───────────────────────────────────────────
+// Quipu's own ontology terms (graph-analysis qualifiers it mints itself, as
+// opposed to the `aegis:` domain ontology). Matches the schemaSpace advertised
+// by the reconciliation endpoint (semweb::reconcile_manifest).
+
+pub const QUIPU: &str = "https://quipu.dev/ontology/";
+
 // ── Commonly-used IRIs ─────────────────────────────────────────
 
 pub const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";


### PR DESCRIPTION
## What (aegis-1p0 Gap 5)
Adds an optional `confidence` field to episode edges so agents can grade how trustworthy an AUTO-extracted fact is — an enum (`EXTRACTED`/`INFERRED`/`AMBIGUOUS`) or a `0`–`1` number. Prerequisite for trusting graph-extract output at scale; the graph-extract skill already emits this forward-compatibly.

## How
- New `Edge.confidence: Option<serde_json::Value>` (`#[serde(default)]`) — picked up automatically on `POST /episode`.
- When present, the statement is **reified** (`rdf:Statement` over `rdf:subject`/`predicate`/`object`) and qualified with `quipu:confidence`, keeping it SPARQL-queryable. The bare triple is **always** asserted too (additive, not a replacement).
- Reification IRI is derived deterministically from the triple → re-ingest dedups at fact level rather than accumulating.
- Confidence folded into the episode content hash so a changed grade isn't mistaken for a no-op re-ingest.
- New `quipu:` namespace (`https://quipu.dev/ontology/`, matching the reconciliation schemaSpace).
- Absent field (the common case) = unqualified bare triple → **fully back-compatible**.

## Tests
`edge_without_confidence_is_a_bare_triple` (back-compat), `edge_confidence_enum_persists_and_is_sparql_queryable` (the AC — queries the grade via SPARQL + confirms bare triple coexists), `edge_confidence_numeric_emits_decimal`, `confidence_participates_in_content_hash`. Clippy clean + tests green under both CI feature sets (`--no-default-features`, `--features shacl`).

Docs: `architecture/episodes.md` Edge Fields table + a confidence note with a sample SPARQL query.

Closes hq-cug6. (quipu in hq rig until qp- stands up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)