### PR TITLE
chore: bump version 0.3.1 -> 0.3.2 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "quipu"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quipu"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 description = "AI-native knowledge graph with strict ontology enforcement — Bobbin's knowledge module"
 authors = ["Steve Brown"]


### PR DESCRIPTION
Bump quipu to **0.3.2** so ops can verify the deploy by version, not just sha. The edge confidence qualifier (hq-cug6, PR #29) landed after v0.3.1.

Tag **v0.3.2** should be cut on the post-merge bump commit (whose `Cargo.toml` reads 0.3.2).

Trivial version-only change (Cargo.toml + Cargo.lock). Requested by dearing for a Stiwi-priority deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)